### PR TITLE
Improve ARM detection for M1 chip on macOS 12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.6 (unreleased)
+
+- Improved ARM detection
+
 ## 0.1.6 (2021-03-10)
 
 - Added ARM shared library for Linux

--- a/lib/argon2/kdf.rb
+++ b/lib/argon2/kdf.rb
@@ -15,13 +15,13 @@ module Argon2
       if Gem.win_platform?
         "argon2.dll"
       elsif RbConfig::CONFIG["host_os"] =~ /darwin/i
-        if RbConfig::CONFIG["host_cpu"] =~ /arm/i
+        if RbConfig::CONFIG["host_cpu"] =~ /arm|aarch64/i
           "libargon2.arm64.dylib"
         else
           "libargon2.dylib"
         end
       else
-        if RbConfig::CONFIG["host_cpu"] =~ /aarch64/i
+        if RbConfig::CONFIG["host_cpu"] =~ /arm|aarch64/i
           "libargon2.arm64.so"
         else
           "libargon2.so"


### PR DESCRIPTION
* as macOS Moneterey 12.1 and M1 chip report `aarch64` as  `host_cpu`

```
> RbConfig::CONFIG["host_cpu"]
=> "aarch64"
```


---


Hey!

Thanks for this library. I believe I'm experiencing the same issue as already outlined and fixed here:

https://github.com/ankane/libmf-ruby/issues/3

https://github.com/ankane/libmf-ruby/commit/ce0f281163c48aa066b01d21728f02e417c9b664

I copied the solution over, and has worked for me.

Error details before this:

```ruby
Fiddle::DLError: dlopen(/Users/martin/.rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/argon2-kdf-0.1.5/vendor/libargon2.dylib, 0x0009): tried: '/Users/martin/.rbenv/versions/2.6.9/lib/ruby/gems/2.6.0/gems/argon2-kdf-0.1.5/vendor/libargon2.dylib' (mach-o file, but is an incompatible architecture (have 'x86_64', need 'arm64e')), '/usr/local/lib/libargon2.dylib' (no such file), '/usr/lib/libargon2.dylib' (no such file)
from /Users/martin/.rbenv/versions/2.6.9/lib/ruby/2.6.0/fiddle.rb:47:in `initialize'
```

```ruby
[2] pry(main)> RbConfig::CONFIG["host_cpu"]                                                                        
=> "aarch64"
[3] pry(main)> RbConfig::CONFIG["host_os"]                                                                         
=> "darwin21.1.0"
```

Let me know if you need any more details. Thank you!