### PR TITLE
Implement `encoded` variants like argon2id_encoded

### DIFF
--- a/lib/argon2/kdf.rb
+++ b/lib/argon2/kdf.rb
@@ -46,6 +46,18 @@ module Argon2
         kdf(:argon2id, pass, salt, t, m, p, length)
       end
 
+      def argon2i_encoded(pass, salt:, t:, m:, p:, length:)
+        encoded(:argon2i, pass, salt, t, m, p, length)
+      end
+
+      def argon2d_encoded(pass, salt:, t:, m:, p:, length:)
+        encoded(:argon2d, pass, salt, t, m, p, length)
+      end
+
+      def argon2id_encoded(pass, salt:, t:, m:, p:, length:)
+        encoded(:argon2id, pass, salt, t, m, p, length)
+      end
+
       private
 
       def kdf(variant, pass, salt, t, m, p, length)
@@ -54,6 +66,18 @@ module Argon2
         hash = Fiddle::Pointer.malloc(length)
         check_status FFI.send("#{variant}_hash_raw", t, 1 << m, p, pwd, pwd.size, salt, salt.size, hash, hash.size)
         hash[0, hash.size]
+      end
+
+      ARGON2_TYPES = { :argon2d => 0, :argon2i => 1, :argon2id => 2 }
+
+      def encoded(variant, pass, salt, t, m, p, length)
+        pwd = Fiddle::Pointer[pass.to_str]
+        salt = Fiddle::Pointer[salt.to_str]
+        encodedlen = FFI.send(:argon2_encodedlen, t, 1 << m, p, salt.size, length, ARGON2_TYPES[variant])
+        encoded = Fiddle::Pointer.malloc(encodedlen)
+        check_status FFI.send("#{variant}_hash_encoded", t, 1 << m, p, pwd, pwd.size, salt, salt.size, length, encoded, encoded.size)
+        # Remove terminating null
+        encoded[0, encoded.size - 1]
       end
 
       def check_status(status)

--- a/lib/argon2/kdf/ffi.rb
+++ b/lib/argon2/kdf/ffi.rb
@@ -23,6 +23,11 @@ module Argon2
       extern "int argon2i_hash_raw(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, void *hash, size_t hashlen)"
       extern "int argon2d_hash_raw(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, void *hash, size_t hashlen)"
       extern "int argon2id_hash_raw(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, void *hash, size_t hashlen)"
+
+      extern "size_t argon2_encodedlen(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, uint32_t saltlen, uint32_t hashlen, int type)"
+      extern "int argon2i_hash_encoded(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, size_t hashlen, char *encoded, size_t encodedlen)"
+      extern "int argon2d_hash_encoded(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, size_t hashlen, char *encoded, size_t encodedlen)"
+      extern "int argon2id_hash_encoded(uint32_t t_cost, uint32_t m_cost, uint32_t parallelism, void *pwd, size_t pwdlen, void *salt, size_t saltlen, size_t hashlen, char *encoded, size_t encodedlen)"
       extern "char *argon2_error_message(int error_code)"
     end
   end


### PR DESCRIPTION
I have a need for encoded argon variant and I found this gem to be a lot simpler than using `argon2` gem.
So I implemented this missing functionality here.

```ruby
Argon2::KDF.argon2id_encoded("pass", salt: "somesalt", t: 3, m: 15, p: 1, length: 32)
=> "$argon2id$v=19$m=32768,t=3,p=1$c29tZXNhbHQ$/nNwrMXYV9+yZMKfKX5Il8o8IG5oOrUWHynU/f/jnI0"
```