### PR TITLE
Prefer using system's argon library rather than bundled one

### DIFF
--- a/lib/argon2/kdf.rb
+++ b/lib/argon2/kdf.rb
@@ -28,7 +28,7 @@ module Argon2
         end
       end
     vendor_lib = File.expand_path("../../vendor/#{lib_name}", __dir__)
-    self.ffi_lib = [vendor_lib]
+    self.ffi_lib = [lib_name + '.1', vendor_lib]
 
     # friendlier error message
     autoload :FFI, "argon2/kdf/ffi"


### PR DESCRIPTION
Prefer using system's argon library rather than bundled one.
It's generally better to use system's library (ie. `/usr/lib/libargon2.so.1`) rather bundled one because system's one will be kept most up-to-date and compiled with distribution's preferred compile flags.
It's often case that libraries bundled in gems get outdated and aren't updated as often as ones provided by distribution.
